### PR TITLE
Fix loader regex for Windows paths

### DIFF
--- a/content/MU123/Keywords.html
+++ b/content/MU123/Keywords.html
@@ -8,7 +8,7 @@
 <link rel="stylesheet" href="../../assets/styles.css"/>
 <script>
 (function(){
-  var path = location.pathname.replace(/\/g,'/');
+  var path = location.pathname.replace(/\\/g,'/');
   var idx  = path.indexOf('/content/');
   var prefix = '';
   if (idx !== -1) {

--- a/content/MU123/Notes/MU123 Guide/2-Technology-Guide.html
+++ b/content/MU123/Notes/MU123 Guide/2-Technology-Guide.html
@@ -7,7 +7,7 @@
 <link rel="stylesheet" href="../../../../assets/styles.css"/>
 <script>
 (function(){
-  var path = location.pathname.replace(/\/g,'/');
+  var path = location.pathname.replace(/\\/g,'/');
   var idx  = path.indexOf('/content/');
   var prefix = '';
   if (idx !== -1) {

--- a/content/MU123/Notes/MU123 Unit 1/0-Contents.html
+++ b/content/MU123/Notes/MU123 Unit 1/0-Contents.html
@@ -8,7 +8,7 @@
 <link rel="stylesheet" href="../../../../assets/styles.css"/>
 <script>
 (function(){
-  var path = location.pathname.replace(/\/g,'/');
+  var path = location.pathname.replace(/\\/g,'/');
   var idx  = path.indexOf('/content/');
   var prefix = '';
   if (idx !== -1) {

--- a/content/MU123/Notes/MU123 Unit 1/1-Welcome.html
+++ b/content/MU123/Notes/MU123 Unit 1/1-Welcome.html
@@ -8,7 +8,7 @@
 <link rel="stylesheet" href="../../../../assets/styles.css"/>
 <script>
 (function(){
-  var path = location.pathname.replace(/\/g,'/');
+  var path = location.pathname.replace(/\\/g,'/');
   var idx  = path.indexOf('/content/');
   var prefix = '';
   if (idx !== -1) {

--- a/content/MU123/Notes/MU123 Unit 1/2-Bidmas.html
+++ b/content/MU123/Notes/MU123 Unit 1/2-Bidmas.html
@@ -8,7 +8,7 @@
 <link rel="stylesheet" href="../../../../assets/styles.css"/>
 <script>
 (function(){
-  var path = location.pathname.replace(/\/g,'/');
+  var path = location.pathname.replace(/\\/g,'/');
   var idx  = path.indexOf('/content/');
   var prefix = '';
   if (idx !== -1) {

--- a/content/MU123/Notes/MU123 Unit 1/3-Powers.html
+++ b/content/MU123/Notes/MU123 Unit 1/3-Powers.html
@@ -8,7 +8,7 @@
 <link rel="stylesheet" href="../../../../assets/styles.css"/>
 <script>
 (function(){
-  var path = location.pathname.replace(/\/g,'/');
+  var path = location.pathname.replace(/\\/g,'/');
   var idx  = path.indexOf('/content/');
   var prefix = '';
   if (idx !== -1) {

--- a/content/MU123/Notes/MU123 Unit 1/4-Sum.html
+++ b/content/MU123/Notes/MU123 Unit 1/4-Sum.html
@@ -8,7 +8,7 @@
 <link rel="stylesheet" href="../../../../assets/styles.css"/>
 <script>
 (function(){
-  var path = location.pathname.replace(/\/g,'/');
+  var path = location.pathname.replace(/\\/g,'/');
   var idx  = path.indexOf('/content/');
   var prefix = '';
   if (idx !== -1) {

--- a/content/MU123/Notes/MU123 Unit 1/5-Difference.html
+++ b/content/MU123/Notes/MU123 Unit 1/5-Difference.html
@@ -8,7 +8,7 @@
 <link rel="stylesheet" href="../../../../assets/styles.css"/>
 <script>
 (function(){
-  var path = location.pathname.replace(/\/g,'/');
+  var path = location.pathname.replace(/\\/g,'/');
   var idx  = path.indexOf('/content/');
   var prefix = '';
   if (idx !== -1) {

--- a/content/MU123/Notes/MU123 Unit 1/6-Product.html
+++ b/content/MU123/Notes/MU123 Unit 1/6-Product.html
@@ -8,7 +8,7 @@
 <link rel="stylesheet" href="../../../../assets/styles.css"/>
 <script>
 (function(){
-  var path = location.pathname.replace(/\/g,'/');
+  var path = location.pathname.replace(/\\/g,'/');
   var idx  = path.indexOf('/content/');
   var prefix = '';
   if (idx !== -1) {

--- a/content/MU123/Notes/MU123 Unit 1/7-Quotient.html
+++ b/content/MU123/Notes/MU123 Unit 1/7-Quotient.html
@@ -8,7 +8,7 @@
 <link rel="stylesheet" href="../../../../assets/styles.css"/>
 <script>
 (function(){
-  var path = location.pathname.replace(/\/g,'/');
+  var path = location.pathname.replace(/\\/g,'/');
   var idx  = path.indexOf('/content/');
   var prefix = '';
   if (idx !== -1) {

--- a/content/TM111/Block 1 - The Digital World/1-Introduction.html
+++ b/content/TM111/Block 1 - The Digital World/1-Introduction.html
@@ -8,7 +8,7 @@
 <link rel="stylesheet" href="../../../assets/styles.css"/>
 <script>
 (function(){
-  var path = location.pathname.replace(/\/g,'/');
+  var path = location.pathname.replace(/\\/g,'/');
   var idx  = path.indexOf('/content/');
   var prefix = '';
   if (idx !== -1) {

--- a/content/TM111/Block 1 - The Digital World/Keywords.html
+++ b/content/TM111/Block 1 - The Digital World/Keywords.html
@@ -8,7 +8,7 @@
 <link rel="stylesheet" href="../../../assets/styles.css"/>
 <script>
 (function(){
-  var path = location.pathname.replace(/\/g,'/');
+  var path = location.pathname.replace(/\\/g,'/');
   var idx  = path.indexOf('/content/');
   var prefix = '';
   if (idx !== -1) {

--- a/content/TM111/Block 1 - The Digital World/Part 1 - Living in a digital world/Activities/Activity 1.1 - How digital is your world.html
+++ b/content/TM111/Block 1 - The Digital World/Part 1 - Living in a digital world/Activities/Activity 1.1 - How digital is your world.html
@@ -8,7 +8,7 @@
 <link rel="stylesheet" href="../../../../../assets/styles.css"/>
 <script>
 (function(){
-  var path = location.pathname.replace(/\/g,'/');
+  var path = location.pathname.replace(/\\/g,'/');
   var idx  = path.indexOf('/content/');
   var prefix = '';
   if (idx !== -1) {

--- a/content/TM111/Block 1 - The Digital World/Part 1 - Living in a digital world/Activities/Activity 1.2.html
+++ b/content/TM111/Block 1 - The Digital World/Part 1 - Living in a digital world/Activities/Activity 1.2.html
@@ -8,7 +8,7 @@
 <link rel="stylesheet" href="../../../../../assets/styles.css"/>
 <script>
 (function(){
-  var path = location.pathname.replace(/\/g,'/');
+  var path = location.pathname.replace(/\\/g,'/');
   var idx  = path.indexOf('/content/');
   var prefix = '';
   if (idx !== -1) {

--- a/content/TM111/Block 1 - The Digital World/Part 1 - Living in a digital world/Notes/1-Part 1 - Introduction.html
+++ b/content/TM111/Block 1 - The Digital World/Part 1 - Living in a digital world/Notes/1-Part 1 - Introduction.html
@@ -8,7 +8,7 @@
 <link rel="stylesheet" href="../../../../../assets/styles.css"/>
 <script>
 (function(){
-  var path = location.pathname.replace(/\/g,'/');
+  var path = location.pathname.replace(/\\/g,'/');
   var idx  = path.indexOf('/content/');
   var prefix = '';
   if (idx !== -1) {

--- a/content/TM111/Block 1 - The Digital World/Part 1 - Living in a digital world/Notes/2-Computers and Commincations - from rairty to ubiquity.html
+++ b/content/TM111/Block 1 - The Digital World/Part 1 - Living in a digital world/Notes/2-Computers and Commincations - from rairty to ubiquity.html
@@ -8,7 +8,7 @@
 <link rel="stylesheet" href="../../../../../assets/styles.css"/>
 <script>
 (function(){
-  var path = location.pathname.replace(/\/g,'/');
+  var path = location.pathname.replace(/\\/g,'/');
   var idx  = path.indexOf('/content/');
   var prefix = '';
   if (idx !== -1) {

--- a/content/TM111/Block 1 - The Digital World/TODO.html
+++ b/content/TM111/Block 1 - The Digital World/TODO.html
@@ -8,7 +8,7 @@
 <link rel="stylesheet" href="../../../assets/styles.css"/>
 <script>
 (function(){
-  var path = location.pathname.replace(/\/g,'/');
+  var path = location.pathname.replace(/\\/g,'/');
   var idx  = path.indexOf('/content/');
   var prefix = '';
   if (idx !== -1) {

--- a/content/TM129/InternetOfThings/1.0-Introduction.html
+++ b/content/TM129/InternetOfThings/1.0-Introduction.html
@@ -7,7 +7,7 @@
 <link rel="stylesheet" href="../../../assets/styles.css"/>
 <script>
 (function(){
-  var path = location.pathname.replace(/\/g,'/');
+  var path = location.pathname.replace(/\\/g,'/');
   var idx  = path.indexOf('/content/');
   var prefix = '';
   if (idx !== -1) {

--- a/content/TM129/InternetOfThings/1.1-IoTDevicesInPacketTracer.html
+++ b/content/TM129/InternetOfThings/1.1-IoTDevicesInPacketTracer.html
@@ -7,7 +7,7 @@
 <link rel="stylesheet" href="../../../assets/styles.css"/>
 <script>
 (function(){
-  var path = location.pathname.replace(/\/g,'/');
+  var path = location.pathname.replace(/\\/g,'/');
   var idx  = path.indexOf('/content/');
   var prefix = '';
   if (idx !== -1) {

--- a/content/TM129/InternetOfThings/webpage-links.html
+++ b/content/TM129/InternetOfThings/webpage-links.html
@@ -7,7 +7,7 @@
 <link rel="stylesheet" href="../../../assets/styles.css"/>
 <script>
 (function(){
-  var path = location.pathname.replace(/\/g,'/');
+  var path = location.pathname.replace(/\\/g,'/');
   var idx  = path.indexOf('/content/');
   var prefix = '';
   if (idx !== -1) {

--- a/content/TM129/Networking Essentials for TM129 - 25J/0-CourseIntroduction.html
+++ b/content/TM129/Networking Essentials for TM129 - 25J/0-CourseIntroduction.html
@@ -7,7 +7,7 @@
 <link rel="stylesheet" href="../../../assets/styles.css"/>
 <script>
 (function(){
-  var path = location.pathname.replace(/\/g,'/');
+  var path = location.pathname.replace(/\\/g,'/');
   var idx  = path.indexOf('/content/');
   var prefix = '';
   if (idx !== -1) {

--- a/content/TM129/Networking Essentials for TM129 - 25J/Module1/1.0 - Introduction.html
+++ b/content/TM129/Networking Essentials for TM129 - 25J/Module1/1.0 - Introduction.html
@@ -7,7 +7,7 @@
 <link rel="stylesheet" href="../../../../assets/styles.css"/>
 <script>
 (function(){
-  var path = location.pathname.replace(/\/g,'/');
+  var path = location.pathname.replace(/\\/g,'/');
   var idx  = path.indexOf('/content/');
   var prefix = '';
   if (idx !== -1) {

--- a/content/TM129/Networking Essentials for TM129 - 25J/Module1/1.1 - NetworkTypes.html
+++ b/content/TM129/Networking Essentials for TM129 - 25J/Module1/1.1 - NetworkTypes.html
@@ -9,7 +9,7 @@
 <link rel="stylesheet" href="../../../../assets/styles.css"/>
 <script>
 (function(){
-  var path = location.pathname.replace(/\/g,'/');
+  var path = location.pathname.replace(/\\/g,'/');
   var idx  = path.indexOf('/content/');
   var prefix = '';
   if (idx !== -1) {

--- a/content/TM129/Networking Essentials for TM129 - 25J/Module1/1.2 - Data Transmission.html
+++ b/content/TM129/Networking Essentials for TM129 - 25J/Module1/1.2 - Data Transmission.html
@@ -8,7 +8,7 @@
 <link rel="stylesheet" href="../../../../assets/styles.css"/>
 <script>
 (function(){
-  var path = location.pathname.replace(/\/g,'/');
+  var path = location.pathname.replace(/\\/g,'/');
   var idx  = path.indexOf('/content/');
   var prefix = '';
   if (idx !== -1) {

--- a/content/TM129/Networking Essentials for TM129 - 25J/Module1/1.3 - Bandwidth-and-Throughput.html
+++ b/content/TM129/Networking Essentials for TM129 - 25J/Module1/1.3 - Bandwidth-and-Throughput.html
@@ -8,7 +8,7 @@
 <link rel="stylesheet" href="../../../../assets/styles.css"/>
 <script>
 (function(){
-  var path = location.pathname.replace(/\/g,'/');
+  var path = location.pathname.replace(/\\/g,'/');
   var idx  = path.indexOf('/content/');
   var prefix = '';
   if (idx !== -1) {

--- a/content/TM129/Networking Essentials for TM129 - 25J/keywords.html
+++ b/content/TM129/Networking Essentials for TM129 - 25J/keywords.html
@@ -8,7 +8,7 @@
 <link rel="stylesheet" href="../../../assets/styles.css"/>
 <script>
 (function(){
-  var path = location.pathname.replace(/\/g,'/');
+  var path = location.pathname.replace(/\\/g,'/');
   var idx  = path.indexOf('/content/');
   var prefix = '';
   if (idx !== -1) {

--- a/content/TM129/Networking Essentials for TM129 - 25J/webpages.html
+++ b/content/TM129/Networking Essentials for TM129 - 25J/webpages.html
@@ -7,7 +7,7 @@
 <link rel="stylesheet" href="../../../assets/styles.css"/>
 <script>
 (function(){
-  var path = location.pathname.replace(/\/g,'/');
+  var path = location.pathname.replace(/\\/g,'/');
   var idx  = path.indexOf('/content/');
   var prefix = '';
   if (idx !== -1) {

--- a/content/TM129/Networking Essentials/0-CourseIntroduction.html
+++ b/content/TM129/Networking Essentials/0-CourseIntroduction.html
@@ -7,7 +7,7 @@
 <link rel="stylesheet" href="../../../assets/styles.css"/>
 <script>
 (function(){
-  var path = location.pathname.replace(/\/g,'/');
+  var path = location.pathname.replace(/\\/g,'/');
   var idx  = path.indexOf('/content/');
   var prefix = '';
   if (idx !== -1) {

--- a/content/TM129/Networking Essentials/Module1/1.0 - Introduction.html
+++ b/content/TM129/Networking Essentials/Module1/1.0 - Introduction.html
@@ -7,7 +7,7 @@
 <link rel="stylesheet" href="../../../../assets/styles.css"/>
 <script>
 (function(){
-  var path = location.pathname.replace(/\/g,'/');
+  var path = location.pathname.replace(/\\/g,'/');
   var idx  = path.indexOf('/content/');
   var prefix = '';
   if (idx !== -1) {

--- a/content/TM129/Networking Essentials/Module1/1.1 - NetworkTypes.html
+++ b/content/TM129/Networking Essentials/Module1/1.1 - NetworkTypes.html
@@ -9,7 +9,7 @@
 <link rel="stylesheet" href="../../../../assets/styles.css"/>
 <script>
 (function(){
-  var path = location.pathname.replace(/\/g,'/');
+  var path = location.pathname.replace(/\\/g,'/');
   var idx  = path.indexOf('/content/');
   var prefix = '';
   if (idx !== -1) {

--- a/content/TM129/Networking Essentials/Module1/1.2 - Data Transmission.html
+++ b/content/TM129/Networking Essentials/Module1/1.2 - Data Transmission.html
@@ -8,7 +8,7 @@
 <link rel="stylesheet" href="../../../../assets/styles.css"/>
 <script>
 (function(){
-  var path = location.pathname.replace(/\/g,'/');
+  var path = location.pathname.replace(/\\/g,'/');
   var idx  = path.indexOf('/content/');
   var prefix = '';
   if (idx !== -1) {

--- a/content/TM129/Networking Essentials/Module1/1.3 - Bandwidth-and-Throughput.html
+++ b/content/TM129/Networking Essentials/Module1/1.3 - Bandwidth-and-Throughput.html
@@ -8,7 +8,7 @@
 <link rel="stylesheet" href="../../../../assets/styles.css"/>
 <script>
 (function(){
-  var path = location.pathname.replace(/\/g,'/');
+  var path = location.pathname.replace(/\\/g,'/');
   var idx  = path.indexOf('/content/');
   var prefix = '';
   if (idx !== -1) {

--- a/content/TM129/Networking Essentials/keywords.html
+++ b/content/TM129/Networking Essentials/keywords.html
@@ -8,7 +8,7 @@
 <link rel="stylesheet" href="../../../assets/styles.css"/>
 <script>
 (function(){
-  var path = location.pathname.replace(/\/g,'/');
+  var path = location.pathname.replace(/\\/g,'/');
   var idx  = path.indexOf('/content/');
   var prefix = '';
   if (idx !== -1) {

--- a/content/TM129/Networking Essentials/webpages.html
+++ b/content/TM129/Networking Essentials/webpages.html
@@ -7,7 +7,7 @@
 <link rel="stylesheet" href="../../../assets/styles.css"/>
 <script>
 (function(){
-  var path = location.pathname.replace(/\/g,'/');
+  var path = location.pathname.replace(/\\/g,'/');
   var idx  = path.indexOf('/content/');
   var prefix = '';
   if (idx !== -1) {


### PR DESCRIPTION
## Summary
- update the shared loader snippet across course HTML pages so the path normalisation regex matches literal backslashes
- verified an affected page loads shared CSS/JS assets without console errors

## Testing
- python -m http.server 8000 (manually exercised Activity 1.1 page in a Playwright browser)

------
https://chatgpt.com/codex/tasks/task_e_68d66e9566f08333855e8f3e6d0b0b88