### PR TITLE
Remove duplicate asset script tags from inline loader pages

### DIFF
--- a/content/MU123/Keywords.html
+++ b/content/MU123/Keywords.html
@@ -49,8 +49,5 @@
         <li><strong>Product</strong>: The result of multiplying two or more numbers.</li>
         <li><strong>Quotient</strong>: The result of dividing one number by another.</li>
     </ul>
-<script defer src="../../assets/content.js"></script>
-<script defer src="../../assets/script.js"></script>
-<script defer src="../../assets/manifest.js"></script>
 </body>
 </html>

--- a/content/MU123/Notes/MU123 Guide/2-Technology-Guide.html
+++ b/content/MU123/Notes/MU123 Guide/2-Technology-Guide.html
@@ -51,8 +51,5 @@
         <li>Online help on the use of Dataplotter is available by clicking help at the top right hand corner of the application</li>
         
     </ul>
-<script defer src="../../../../assets/content.js"></script>
-<script defer src="../../../../assets/script.js"></script>
-<script defer src="../../../../assets/manifest.js"></script>
 </body>
 </html>

--- a/content/MU123/Notes/MU123 Unit 1/0-Contents.html
+++ b/content/MU123/Notes/MU123 Unit 1/0-Contents.html
@@ -50,8 +50,5 @@
     <li><a href="C:\Repos\openUniversity\MU123\Notes\MU123 Unit 1\6-Product.html">Product</a></li>
     <li><a href="C:\Repos\openUniversity\MU123\Notes\MU123 Unit 1\7-Quotient.html">Quotient</a></li>
     </ul>
-<script defer src="../../../../assets/content.js"></script>
-<script defer src="../../../../assets/script.js"></script>
-<script defer src="../../../../assets/manifest.js"></script>
 </body>
 </html>

--- a/content/MU123/Notes/MU123 Unit 1/1-Welcome.html
+++ b/content/MU123/Notes/MU123 Unit 1/1-Welcome.html
@@ -46,8 +46,5 @@
         <li>Mathematics has been used to describe and explain the world for thousands of years</li>
         <li>The regular marks engraved on a piece of bone found in Africa known as the Ishango bone, appear to indicate that people were counting and thinking mathematically over 20,000 years ago</li>
     </ul>
-<script defer src="../../../../assets/content.js"></script>
-<script defer src="../../../../assets/script.js"></script>
-<script defer src="../../../../assets/manifest.js"></script>
 </body>
 </html>

--- a/content/MU123/Notes/MU123 Unit 1/2-Bidmas.html
+++ b/content/MU123/Notes/MU123 Unit 1/2-Bidmas.html
@@ -158,8 +158,5 @@
     <ul>
         <li><a href="https://www.mathsisfun.com/algebra/operations-order-calculator.html">Math is Fun - BIDMAS</a></li>
         <li><a href="https://www.khanacademy.org/math/cc-sixth-grade-math/x0267d782:cc-6th-exponents-and-order-of-operations">Khan Academy - Order of Operations</a></li>
-<script defer src="../../../../assets/content.js"></script>
-<script defer src="../../../../assets/script.js"></script>
-<script defer src="../../../../assets/manifest.js"></script>
 </body>
 </html>

--- a/content/MU123/Notes/MU123 Unit 1/3-Powers.html
+++ b/content/MU123/Notes/MU123 Unit 1/3-Powers.html
@@ -51,8 +51,5 @@
     <ul>
         <li><a href="https://www.mathsisfun.com/definitions/power.html">Math is Fun - Powers</a></li>
         <li><a href="https://www.khanacademy.org/math/cc-sixth-grade-math/x0267d782:cc-6th-exponents-and-order-of-operations">Khan Academy - Exponents</a></li>
-<script defer src="../../../../assets/content.js"></script>
-<script defer src="../../../../assets/script.js"></script>
-<script defer src="../../../../assets/manifest.js"></script>
 </body>
 </html>

--- a/content/MU123/Notes/MU123 Unit 1/4-Sum.html
+++ b/content/MU123/Notes/MU123 Unit 1/4-Sum.html
@@ -58,8 +58,5 @@
     <li><a href="https://www.open.edu/openlearn/science-maths-technology/mathematics-statistics/numbers-units-and-arithmetic">Open University - Numbers, Units and Arithmetic</a></li>
 
     </ul>
-<script defer src="../../../../assets/content.js"></script>
-<script defer src="../../../../assets/script.js"></script>
-<script defer src="../../../../assets/manifest.js"></script>
 </body>
 </html>

--- a/content/MU123/Notes/MU123 Unit 1/5-Difference.html
+++ b/content/MU123/Notes/MU123 Unit 1/5-Difference.html
@@ -51,8 +51,5 @@
         <li><a href="https://www.khanacademy.org/math/cc-3rd-grade-math/cc-3rd-add-subtract-1000/cc-3rd-subtraction-within-1000/e/subtraction-within-1000">Khan Academy - Subtraction within 1000</a></li>
         <li><a href="https://www.khanacademy.org/math/early-math/cc-early-math-add-sub-basics/cc-early-math-add-subtract-10/e/relate-addition-and-subtraction">Khan Academy - Relate Addition and Subtraction</a></li>  
  <li><a href="https://www.open.edu/openlearn/science-maths-technology/mathematics-statistics/numbers-units-and-arithmetic">Open University - Numbers, Units and Arithmetic</a></li>
-<script defer src="../../../../assets/content.js"></script>
-<script defer src="../../../../assets/script.js"></script>
-<script defer src="../../../../assets/manifest.js"></script>
 </body>
 </html>

--- a/content/MU123/Notes/MU123 Unit 1/6-Product.html
+++ b/content/MU123/Notes/MU123 Unit 1/6-Product.html
@@ -51,8 +51,5 @@
         <li><a href="https://www.khanacademy.org/math/cc-3rd-grade-math/cc-3rd-multiply-1000/cc-3rd-multiplication-within-1000/e/multiplication-within-1000">Khan Academy - Multiplication within 1000</a></li>
    <li><a href="https://www.open.edu/openlearn/science-maths-technology/mathematics-statistics/squares-roots-and-powers/content-section-0?active-tab=description-tab&_gl=1*arazke*_gcl_au*NzM4MjI2NzgxLjE3NTI4MzE0MzM.">Open University - squares-roots-and-powers</a></li>
     </ul>
-<script defer src="../../../../assets/content.js"></script>
-<script defer src="../../../../assets/script.js"></script>
-<script defer src="../../../../assets/manifest.js"></script>
 </body>
 </html>

--- a/content/MU123/Notes/MU123 Unit 1/7-Quotient.html
+++ b/content/MU123/Notes/MU123 Unit 1/7-Quotient.html
@@ -55,8 +55,5 @@
         <li><a href="https://www.mathsisfun.com/numbers/division.html">Math is Fun - Division</a></li>
         <li><a href="https://www.khanacademy.org/math/cc-3rd-grade-math/cc-3rd-divide-1000/cc-3rd-division-within-1000/e/division-within-1000">Khan Academy - Division within 1000</a></li>
 
-<script defer src="../../../../assets/content.js"></script>
-<script defer src="../../../../assets/script.js"></script>
-<script defer src="../../../../assets/manifest.js"></script>
 </body>
 </html>

--- a/content/TM111/Block 1 - The Digital World/1-Introduction.html
+++ b/content/TM111/Block 1 - The Digital World/1-Introduction.html
@@ -56,8 +56,5 @@
     <li>You will be introduced to concepts such as usability and accessibility</li>
     <li>You will start your personal and professional development planning</li>
 </ul>
-<script defer src="../../../assets/content.js"></script>
-<script defer src="../../../assets/script.js"></script>
-<script defer src="../../../assets/manifest.js"></script>
 </body>
 </html>

--- a/content/TM111/Block 1 - The Digital World/Keywords.html
+++ b/content/TM111/Block 1 - The Digital World/Keywords.html
@@ -57,8 +57,5 @@
         
         
     </ul>
-<script defer src="../../../assets/content.js"></script>
-<script defer src="../../../assets/script.js"></script>
-<script defer src="../../../assets/manifest.js"></script>
 </body>
 </html>

--- a/content/TM111/Block 1 - The Digital World/Part 1 - Living in a digital world/Activities/Activity 1.1 - How digital is your world.html
+++ b/content/TM111/Block 1 - The Digital World/Part 1 - Living in a digital world/Activities/Activity 1.1 - How digital is your world.html
@@ -40,8 +40,5 @@
     <h1>Activity 1.1 - How digital is your world?</h1>
     <p>How digital is your world? You should now completer the "how digital is your life?" quiz which you will find on the module website.  Note: there are no right or wrong answers in this quiz
     <p>You might return to the quiz at the end of TM111 to see whether your responses have changed</p>
-<script defer src="../../../../../assets/content.js"></script>
-<script defer src="../../../../../assets/script.js"></script>
-<script defer src="../../../../../assets/manifest.js"></script>
 </body>
 </html>

--- a/content/TM111/Block 1 - The Digital World/Part 1 - Living in a digital world/Activities/Activity 1.2.html
+++ b/content/TM111/Block 1 - The Digital World/Part 1 - Living in a digital world/Activities/Activity 1.2.html
@@ -67,8 +67,5 @@
         <li>Over-reliance can lead to complacency in navigation skills</li>
         <li>Cost of devices and data plans for real-time updates</li>
     </ul>
-<script defer src="../../../../../assets/content.js"></script>
-<script defer src="../../../../../assets/script.js"></script>
-<script defer src="../../../../../assets/manifest.js"></script>
 </body>
 </html>

--- a/content/TM111/Block 1 - The Digital World/Part 1 - Living in a digital world/Notes/1-Part 1 - Introduction.html
+++ b/content/TM111/Block 1 - The Digital World/Part 1 - Living in a digital world/Notes/1-Part 1 - Introduction.html
@@ -48,8 +48,5 @@
     <li>Some examples will move into the worlds of crime and terror, where information is transmitted that others want to intercept, control or suppress</li>
     <li>Effective participation in the digital world therefore requires you to become aware of many technical, social and ethical pitfalls, as well as some ways you can avoid them</li>
     </ul>
-<script defer src="../../../../../assets/content.js"></script>
-<script defer src="../../../../../assets/script.js"></script>
-<script defer src="../../../../../assets/manifest.js"></script>
 </body>
 </html>

--- a/content/TM111/Block 1 - The Digital World/Part 1 - Living in a digital world/Notes/2-Computers and Commincations - from rairty to ubiquity.html
+++ b/content/TM111/Block 1 - The Digital World/Part 1 - Living in a digital world/Notes/2-Computers and Commincations - from rairty to ubiquity.html
@@ -87,8 +87,5 @@
     <li>Distance is no longer a barrier to commercial or social contact for those of us connected to suitable networks</li>
     <li>Some people may find it difficult to imagine not having access to information and services that play a crucial role in their daily lives.</li>
     <li>Others may feel that they have no part to play in the digital world because their network access is very limited or even non-existent.</li></ul>
-<script defer src="../../../../../assets/content.js"></script>
-<script defer src="../../../../../assets/script.js"></script>
-<script defer src="../../../../../assets/manifest.js"></script>
 </body>
 </html>

--- a/content/TM111/Block 1 - The Digital World/TODO.html
+++ b/content/TM111/Block 1 - The Digital World/TODO.html
@@ -43,8 +43,5 @@
     <ul>
         <li>Complete Activity 1.1: Complete the "how digital is your life"? quiz, which is on the module website</li>
     </ul>
-<script defer src="../../../assets/content.js"></script>
-<script defer src="../../../assets/script.js"></script>
-<script defer src="../../../assets/manifest.js"></script>
 </body>
 </html>

--- a/content/TM129/InternetOfThings/1.0-Introduction.html
+++ b/content/TM129/InternetOfThings/1.0-Introduction.html
@@ -58,8 +58,5 @@
         <li>Packet Tracer contains many features to support the IoT. Packet Tracer has a wide variety of sensors, actuators, and smart devices that will allow you to design smart homes, smart cities, smart factories, and smart power grids.</li>
         <li>You will learn to configure and modify scripts to make them function, and to control devices remotely.</li>
     </ul>
-<script defer src="../../../assets/content.js"></script>
-<script defer src="../../../assets/script.js"></script>
-<script defer src="../../../assets/manifest.js"></script>
 </body>
 </html>

--- a/content/TM129/InternetOfThings/1.1-IoTDevicesInPacketTracer.html
+++ b/content/TM129/InternetOfThings/1.1-IoTDevicesInPacketTracer.html
@@ -45,8 +45,5 @@
 <img src="./graphics/0.0-EndDevices.png" alt="End Devices">
 <l
 </ul>
-<script defer src="../../../assets/content.js"></script>
-<script defer src="../../../assets/script.js"></script>
-<script defer src="../../../assets/manifest.js"></script>
 </body>
 </html>

--- a/content/TM129/InternetOfThings/webpage-links.html
+++ b/content/TM129/InternetOfThings/webpage-links.html
@@ -42,8 +42,5 @@
 </a></li>
 <li><a href="https://www.netacad.com/help">Netacad help</a></li>
     </ul>
-<script defer src="../../../assets/content.js"></script>
-<script defer src="../../../assets/script.js"></script>
-<script defer src="../../../assets/manifest.js"></script>
 </body>
 </html>

--- a/content/TM129/Networking Essentials for TM129 - 25J/0-CourseIntroduction.html
+++ b/content/TM129/Networking Essentials for TM129 - 25J/0-CourseIntroduction.html
@@ -48,8 +48,5 @@
     <li>The course provides an introduction to troubleshooting methodologies and examines how to troubleshoot some of the most common networking issues<li>
     <li>The learner will review different equipment hardware and will need to configure network setting on different devices and operating systems</li>
     </ul>
-<script defer src="../../../assets/content.js"></script>
-<script defer src="../../../assets/script.js"></script>
-<script defer src="../../../assets/manifest.js"></script>
 </body>
 </html>

--- a/content/TM129/Networking Essentials for TM129 - 25J/Module1/1.0 - Introduction.html
+++ b/content/TM129/Networking Essentials for TM129 - 25J/Module1/1.0 - Introduction.html
@@ -43,8 +43,5 @@
     <ul><li>Network Types: Explain the concepts of a network</li>
     <li>Data Transmission: Describe network data</li>
     <li>Bandwidth and Throughput: Explain network transmission and capacity</li>
-<script defer src="../../../../assets/content.js"></script>
-<script defer src="../../../../assets/script.js"></script>
-<script defer src="../../../../assets/manifest.js"></script>
 </body>
 </html>

--- a/content/TM129/Networking Essentials for TM129 - 25J/Module1/1.1 - NetworkTypes.html
+++ b/content/TM129/Networking Essentials for TM129 - 25J/Module1/1.1 - NetworkTypes.html
@@ -123,8 +123,5 @@
         <li><strong>Medical Devices:</strong> Medical devices such as pacemakers, insulin pumps, and hospital monitors provide users or medical professionals with direct feedback or alerts when vital signs are at specific levels.</li>
       </ul>
   </main>
-<script defer src="../../../../assets/content.js"></script>
-<script defer src="../../../../assets/script.js"></script>
-<script defer src="../../../../assets/manifest.js"></script>
 </body>
 </html>

--- a/content/TM129/Networking Essentials for TM129 - 25J/Module1/1.2 - Data Transmission.html
+++ b/content/TM129/Networking Essentials for TM129 - 25J/Module1/1.2 - Data Transmission.html
@@ -127,9 +127,6 @@
                 <li>Larger networks employ fiber-optic cables in order to reliably carry signals for longer distances.
                 </li>
             </ul>
-<script defer src="../../../../assets/content.js"></script>
-<script defer src="../../../../assets/script.js"></script>
-<script defer src="../../../../assets/manifest.js"></script>
 </body>
 
 </html>

--- a/content/TM129/Networking Essentials for TM129 - 25J/Module1/1.3 - Bandwidth-and-Throughput.html
+++ b/content/TM129/Networking Essentials for TM129 - 25J/Module1/1.3 - Bandwidth-and-Throughput.html
@@ -93,9 +93,6 @@
             lower bandwidth to create a slowdown of the throughput of the entire network.</li>
         <li>There are many online speed tests that can reveal the throughput of an internet connection.</li>
     </ul>
-<script defer src="../../../../assets/content.js"></script>
-<script defer src="../../../../assets/script.js"></script>
-<script defer src="../../../../assets/manifest.js"></script>
 </body>
 
 </html>

--- a/content/TM129/Networking Essentials for TM129 - 25J/keywords.html
+++ b/content/TM129/Networking Essentials for TM129 - 25J/keywords.html
@@ -81,9 +81,6 @@
 
 
     </ul>
-<script defer src="../../../assets/content.js"></script>
-<script defer src="../../../assets/script.js"></script>
-<script defer src="../../../assets/manifest.js"></script>
 </body>
 
 </html>

--- a/content/TM129/Networking Essentials for TM129 - 25J/webpages.html
+++ b/content/TM129/Networking Essentials for TM129 - 25J/webpages.html
@@ -39,8 +39,5 @@
     <h1>Webpages</h1>   
     <ul>
     <li><a href="https://www.netacad.com/launch?id=8a8cf0a6-7afd-45be-b486-e0086c7a61c4&tab=curriculum&view=aff0946f-3805-5b36-93d9-3e60aef38121">Networking Essentials for TM129-25J</a></li></ul>
-<script defer src="../../../assets/content.js"></script>
-<script defer src="../../../assets/script.js"></script>
-<script defer src="../../../assets/manifest.js"></script>
 </body>
 </html>

--- a/content/TM129/Networking Essentials/0-CourseIntroduction.html
+++ b/content/TM129/Networking Essentials/0-CourseIntroduction.html
@@ -48,8 +48,5 @@
     <li>The course provides an introduction to troubleshooting methodologies and examines how to troubleshoot some of the most common networking issues<li>
     <li>The learner will review different equipment hardware and will need to configure network setting on different devices and operating systems</li>
     </ul>
-<script defer src="../../../assets/content.js"></script>
-<script defer src="../../../assets/script.js"></script>
-<script defer src="../../../assets/manifest.js"></script>
 </body>
 </html>

--- a/content/TM129/Networking Essentials/Module1/1.0 - Introduction.html
+++ b/content/TM129/Networking Essentials/Module1/1.0 - Introduction.html
@@ -43,8 +43,5 @@
     <ul><li>Network Types: Explain the concepts of a network</li>
     <li>Data Transmission: Describe network data</li>
     <li>Bandwidth and Throughput: Explain network transmission and capacity</li>
-<script defer src="../../../../assets/content.js"></script>
-<script defer src="../../../../assets/script.js"></script>
-<script defer src="../../../../assets/manifest.js"></script>
 </body>
 </html>

--- a/content/TM129/Networking Essentials/Module1/1.1 - NetworkTypes.html
+++ b/content/TM129/Networking Essentials/Module1/1.1 - NetworkTypes.html
@@ -123,8 +123,5 @@
         <li><strong>Medical Devices:</strong> Medical devices such as pacemakers, insulin pumps, and hospital monitors provide users or medical professionals with direct feedback or alerts when vital signs are at specific levels.</li>
       </ul>
   </main>
-<script defer src="../../../../assets/content.js"></script>
-<script defer src="../../../../assets/script.js"></script>
-<script defer src="../../../../assets/manifest.js"></script>
 </body>
 </html>

--- a/content/TM129/Networking Essentials/Module1/1.2 - Data Transmission.html
+++ b/content/TM129/Networking Essentials/Module1/1.2 - Data Transmission.html
@@ -127,9 +127,6 @@
                 <li>Larger networks employ fiber-optic cables in order to reliably carry signals for longer distances.
                 </li>
             </ul>
-<script defer src="../../../../assets/content.js"></script>
-<script defer src="../../../../assets/script.js"></script>
-<script defer src="../../../../assets/manifest.js"></script>
 </body>
 
 </html>

--- a/content/TM129/Networking Essentials/Module1/1.3 - Bandwidth-and-Throughput.html
+++ b/content/TM129/Networking Essentials/Module1/1.3 - Bandwidth-and-Throughput.html
@@ -93,9 +93,6 @@
             lower bandwidth to create a slowdown of the throughput of the entire network.</li>
         <li>There are many online speed tests that can reveal the throughput of an internet connection.</li>
     </ul>
-<script defer src="../../../../assets/content.js"></script>
-<script defer src="../../../../assets/script.js"></script>
-<script defer src="../../../../assets/manifest.js"></script>
 </body>
 
 </html>

--- a/content/TM129/Networking Essentials/keywords.html
+++ b/content/TM129/Networking Essentials/keywords.html
@@ -81,9 +81,6 @@
 
 
     </ul>
-<script defer src="../../../assets/content.js"></script>
-<script defer src="../../../assets/script.js"></script>
-<script defer src="../../../assets/manifest.js"></script>
 </body>
 
 </html>

--- a/content/TM129/Networking Essentials/webpages.html
+++ b/content/TM129/Networking Essentials/webpages.html
@@ -39,8 +39,5 @@
     <h1>Webpages</h1>   
     <ul>
     <li><a href="https://www.netacad.com/launch?id=8a8cf0a6-7afd-45be-b486-e0086c7a61c4&tab=curriculum&view=aff0946f-3805-5b36-93d9-3e60aef38121">Networking Essentials for TM129-25J</a></li></ul>
-<script defer src="../../../assets/content.js"></script>
-<script defer src="../../../assets/script.js"></script>
-<script defer src="../../../assets/manifest.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove hard-coded deferred asset script tags from content pages that already include the inline loader
- ensure TM111, TM129, and MU123 materials rely on the loader for manifest, script, and content bundles

## Testing
- python -m http.server 8000 (manual verification via Playwright to confirm no OU_PROGRESS_KEY console errors)


------
https://chatgpt.com/codex/tasks/task_e_68d672fe2bd88333b96d6def9583f37b